### PR TITLE
Drop Plone 4.0 support and fix tests

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,6 +5,9 @@ Changelog
 1.1 (unreleased)
 ----------------
 
+- Drop Plone 4.0 Support.
+  [jone]
+
 - Quota handler now also works in portal_factory.
   Ex. zope.lifecycleevent.interfaces.IObjectCreatedEvent works correctly.
 

--- a/ftw/quota/testing.py
+++ b/ftw/quota/testing.py
@@ -1,6 +1,7 @@
 from ftw.builder.testing import BUILDER_LAYER
+from ftw.quota.interfaces import IQuotaAware
 from ftw.quota.interfaces import IQuotaSupport
-from ftw.testing.layer import ComponentRegistryLayer
+from plone.app.blob.content import ATBlob
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import login
 from plone.app.testing import PLONE_FIXTURE
@@ -12,17 +13,6 @@ from Products.ATContentTypes.content.folder import ATFolder
 from zope.configuration import xmlconfig
 from zope.interface import classImplements
 
-
-class ZCMLLayer(ComponentRegistryLayer):
-
-    def setUp(self):
-        super(ZCMLLayer, self).setUp()
-
-        import ftw.quota.tests
-        self.load_zcml_file('test.zcml', ftw.quota.tests)
-
-
-ZCML_LAYER = ZCMLLayer()
 
 
 class FtwQuotaLayer(PloneSandboxLayer):
@@ -38,8 +28,8 @@ class FtwQuotaLayer(PloneSandboxLayer):
         xmlconfig.file('configure.zcml', ftw.quota,
                        context=configurationContext)
 
-        # let folders always have quotas enabled in tests.
         classImplements(ATFolder, IQuotaSupport)
+        classImplements(ATBlob, IQuotaAware)
 
     def setUpPloneSite(self, portal):
         setRoles(portal, TEST_USER_ID, ['Manager'])

--- a/ftw/quota/testing.py
+++ b/ftw/quota/testing.py
@@ -1,7 +1,12 @@
+from ftw.builder.testing import BUILDER_LAYER
 from ftw.testing.layer import ComponentRegistryLayer
 from plone.app.testing import IntegrationTesting
+from plone.app.testing import login
+from plone.app.testing import PLONE_FIXTURE
 from plone.app.testing import PloneSandboxLayer
-from plone.app.testing import setRoles, TEST_USER_ID, TEST_USER_NAME, login
+from plone.app.testing import setRoles
+from plone.app.testing import TEST_USER_ID
+from plone.app.testing import TEST_USER_NAME
 from zope.configuration import xmlconfig
 
 
@@ -18,6 +23,8 @@ ZCML_LAYER = ZCMLLayer()
 
 
 class FtwQuotaLayer(PloneSandboxLayer):
+
+    defaultBases = (PLONE_FIXTURE, BUILDER_LAYER)
 
     def setUpZope(self, app, configurationContext):
         import archetypes.schemaextender

--- a/ftw/quota/testing.py
+++ b/ftw/quota/testing.py
@@ -1,4 +1,5 @@
 from ftw.builder.testing import BUILDER_LAYER
+from ftw.quota.interfaces import IQuotaSupport
 from ftw.testing.layer import ComponentRegistryLayer
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import login
@@ -7,7 +8,9 @@ from plone.app.testing import PloneSandboxLayer
 from plone.app.testing import setRoles
 from plone.app.testing import TEST_USER_ID
 from plone.app.testing import TEST_USER_NAME
+from Products.ATContentTypes.content.folder import ATFolder
 from zope.configuration import xmlconfig
+from zope.interface import classImplements
 
 
 class ZCMLLayer(ComponentRegistryLayer):
@@ -34,6 +37,9 @@ class FtwQuotaLayer(PloneSandboxLayer):
         import ftw.quota
         xmlconfig.file('configure.zcml', ftw.quota,
                        context=configurationContext)
+
+        # let folders always have quotas enabled in tests.
+        classImplements(ATFolder, IQuotaSupport)
 
     def setUpPloneSite(self, portal):
         setRoles(portal, TEST_USER_ID, ['Manager'])

--- a/ftw/quota/tests/quota.txt
+++ b/ftw/quota/tests/quota.txt
@@ -11,12 +11,6 @@ Create a folder
     >>> myid = folder.invokeFactory('Folder', 'qfolder')
     >>> qfolder = folder[myid]
     >>> IQuotaSupport.providedBy(qfolder)
-    False
-
-Enable quota support
-
-    >>> alsoProvides(qfolder, IQuotaSupport)
-    >>> IQuotaSupport.providedBy(qfolder)
     True
 
 By default, the quota limit is set to 50MB and quota is enabled.
@@ -143,7 +137,7 @@ Space usage should remain the same.
     >>> file1 = subfolder[myid]
     >>> file1.processForm()
     >>> schema.getField('usage').get(qfolder)
-    70
+    50
     >>> dummy = transaction.savepoint() # needed for cutObjects
     >>> cp_data = subfolder.manage_cutObjects(ids=[myid,])
     >>> dummy = qfolder.manage_pasteObjects(cp_data)

--- a/ftw/quota/tests/test.zcml
+++ b/ftw/quota/tests/test.zcml
@@ -1,9 +1,0 @@
-<configure
-    xmlns="http://namespaces.zope.org/zope">
-
-    <include package="Products.Five" file="meta.zcml" />
-    <include package="zope.annotation" />
-
-    <include package="ftw.quota" />
-
-</configure>

--- a/ftw/quota/tests/test_adapters.py
+++ b/ftw/quota/tests/test_adapters.py
@@ -1,56 +1,43 @@
-from Products.Archetypes.interfaces import IBaseObject
+from ftw.builder import Builder
+from ftw.builder import create
 from ftw.quota.interfaces import IQuotaSize
-from ftw.quota.testing import ZCML_LAYER
-from ftw.testing import MockTestCase
-from zope.annotation.interfaces import IAttributeAnnotatable
+from ftw.quota.testing import FTW_QUOTA_INTEGRATION_TESTING
+from StringIO import StringIO
+from unittest2 import TestCase
 from zope.component import queryAdapter
 
 
-class TestQuotaSizeAnnotation(MockTestCase):
+def make_file_like_object(content, filename='foo.doc'):
+    data = StringIO(content)
+    data.filename = filename
+    return data
 
-    layer = ZCML_LAYER
 
-    def setUp(self):
-        super(TestQuotaSizeAnnotation, self).setUp()
-        self.context = self.providing_stub(
-            [IBaseObject, IAttributeAnnotatable])
-
-    def test_component_registered(self):
-        self.replay()
-
-        self.assertNotEquals(queryAdapter(self.context, IQuotaSize), None)
+class TestQuotaSizeAnnotation(TestCase):
+    layer = FTW_QUOTA_INTEGRATION_TESTING
 
     def test_size_is_stored(self):
-        self.expect(self.context.get_size()).result(10)
-        self.replay()
-
-        size = queryAdapter(self.context, IQuotaSize)
-        size.update_size()
-        self.assertEqual(size.get_size(), 10)
+        doc = create(Builder('file').attach_file_containing(' ' * 30))
+        size = queryAdapter(doc, IQuotaSize)
+        self.assertEqual(30, size.get_size())
 
     def test_updating_size_returns_difference(self):
-        with self.mocker.order():
-            self.expect(self.context.get_size()).result(30)
-            self.expect(self.context.get_size()).result(50)
-            self.expect(self.context.get_size()).result(40)
+        doc = create(Builder('file').attach_file_containing(''))
+        size = queryAdapter(doc, IQuotaSize)
+        self.assertEqual(0, size.get_size())
 
-        self.replay()
+        doc.setFile(make_file_like_object(' ' * 10))
+        self.assertEqual(10, size.update_size())
+        self.assertEqual(10, size.get_size())
 
-        size = queryAdapter(self.context, IQuotaSize)
+        doc.setFile(make_file_like_object(' ' * 30))
+        self.assertEqual(20, size.update_size())
+        self.assertEqual(30, size.get_size())
 
-        self.assertEqual(size.update_size(), 30)
-        self.assertEqual(size.get_size(), 30)
+    def test_get_size_updates_size_only_on_first_call(self):
+        doc = create(Builder('file').attach_file_containing(' ' * 10))
+        size = queryAdapter(doc, IQuotaSize)
 
-        self.assertEqual(size.update_size(), 20)
-        self.assertEqual(size.get_size(), 50)
-
-        self.assertEqual(size.update_size(), -10)
-        self.assertEqual(size.get_size(), 40)
-
-    def test_get_size_updates_size(self):
-        self.expect(self.context.get_size()).result(20)
-
-        self.replay()
-        size = queryAdapter(self.context, IQuotaSize)
-        self.assertEqual(size.get_size(), 20)
-        self.assertEqual(size.get_size(), 20)
+        self.assertEqual(10, size.get_size())
+        doc.setFile(make_file_like_object(' ' * 20))
+        self.assertEqual(10, size.get_size())

--- a/ftw/quota/tests/test_extender.py
+++ b/ftw/quota/tests/test_extender.py
@@ -1,32 +1,27 @@
-from Products.Archetypes.interfaces import IBaseObject
 from archetypes.schemaextender.field import ExtensionField
-from ftw.quota.interfaces import IQuotaSupport
-from ftw.quota.testing import ZCML_LAYER
-from ftw.testing import MockTestCase
+from ftw.builder import Builder
+from ftw.builder import create
+from ftw.quota.testing import FTW_QUOTA_INTEGRATION_TESTING
+from unittest2 import TestCase
 from zope.component import queryAdapter
 
 
-class TestQuotaExtender(MockTestCase):
-
-    layer = ZCML_LAYER
+class TestQuotaExtender(TestCase):
+    layer = FTW_QUOTA_INTEGRATION_TESTING
 
     def test_adapts_IQuotaSupport_only(self):
-        obj = self.providing_stub([IBaseObject])
-        self.replay()
-        adapter = queryAdapter(obj, name="ftw.quota.extender.QuotaExtender")
-        self.assertEqual(adapter, None)
+        context = create(Builder('file'))
+        adapter = queryAdapter(context, name="ftw.quota.extender.QuotaExtender")
+        self.assertFalse(adapter)
 
     def test_adapts_IQuotaSupport(self):
-        obj = self.providing_stub([IQuotaSupport])
-        self.replay()
-        adapter = queryAdapter(obj, name="ftw.quota.extender.QuotaExtender")
-        self.assertNotEqual(adapter, None)
+        context = create(Builder('folder'))
+        adapter = queryAdapter(context, name="ftw.quota.extender.QuotaExtender")
+        self.assertTrue(adapter)
 
     def test_fields_are_extension_fields(self):
-        obj = self.providing_stub([IQuotaSupport])
-        self.replay()
-
-        adapter = queryAdapter(obj, name="ftw.quota.extender.QuotaExtender")
+        context = create(Builder('folder'))
+        adapter = queryAdapter(context, name="ftw.quota.extender.QuotaExtender")
         fields = adapter.getFields()
 
         for field in fields:

--- a/ftw/quota/tests/test_handlers.py
+++ b/ftw/quota/tests/test_handlers.py
@@ -1,134 +1,47 @@
-from borg.localrole.interfaces import IFactoryTempFolder
+from ftw.builder import Builder
+from ftw.builder import create
 from ftw.quota import handlers
-from ftw.quota.interfaces import IQuotaSupport, IQuotaAware
-from ftw.quota.testing import ZCML_LAYER
-from ftw.testing import MockTestCase
-from mocker import ANY
-from Products.Archetypes.interfaces import IBaseObject
-from Products.CMFCore.interfaces import ISiteRoot
+from ftw.quota.testing import FTW_QUOTA_INTEGRATION_TESTING
+from unittest2 import TestCase
 from zExceptions import Redirect
-from zope.annotation.interfaces import IAttributeAnnotatable
 
 
-class TestRaiseQuotaExceeded(MockTestCase):
-
-    layer = ZCML_LAYER
+class TestRaiseQuotaExceeded(TestCase):
+    layer = FTW_QUOTA_INTEGRATION_TESTING
 
     def test_exceeding_raised_when_quota_enforced(self):
-        context = self.providing_stub(IQuotaSupport)
-        self.expect(context.Schema().getField(
-                'enforce').get(context)).result(True)
-        self.expect(context.absolute_url()).result('/plone/foo')
-
-        request = self.stub_request(interfaces=[IAttributeAnnotatable])
-        self.expect(context.REQUEST).result(request)
-        cookies = {}
-        self.expect(request.cookies).result(cookies)
-
-        plone_utils = self.mocker.mock()
-        self.mock_tool(plone_utils, 'plone_utils')
-        self.expect(plone_utils.addPortalMessage(ANY, 'error'))
-
-        self.replay()
-
+        context = create(Builder('folder')
+                         .having(enforce=True))
         with self.assertRaises(Redirect) as cm:
             handlers.raise_quota_exceeded(context)
-
-        self.assertEqual(cm.exception.args, ('/plone/foo',))
+        self.assertEqual(cm.exception.args, ('http://nohost/plone/folder',))
 
     def test_no_exceeding_raised_when_not_enforced(self):
-        context = self.providing_stub(IQuotaSupport)
-        self.expect(context.Schema().getField(
-                'enforce').get(context)).result(False)
-
-        self.replay()
+        context = create(Builder('folder')
+                         .having(enforce=False))
         handlers.raise_quota_exceeded(context)
 
-
-class TestFindQuotaParent(MockTestCase):
-
-    layer = ZCML_LAYER
-
     def test_context_is_quota_container(self):
-        context = self.providing_stub([IBaseObject, IQuotaSupport])
-        self.replay()
-        self.assertEqual(handlers.find_quota_parent(context), context)
+        folder = create(Builder('folder'))
+        self.assertEqual(folder, handlers.find_quota_parent(folder))
 
     def test_parent_is_quota_container(self):
-        parent = self.providing_stub([IBaseObject, IQuotaSupport])
-        context = self.providing_stub([IBaseObject])
-        self.set_parent(context, parent)
-
-        self.replay()
-        self.assertEqual(handlers.find_quota_parent(context), parent)
-
-    def test_nested_quota_containers(self):
-        context = self.providing_stub([IBaseObject])
-        first = self.providing_stub([IBaseObject, IQuotaSupport])
-        second = self.providing_stub([IBaseObject, IQuotaSupport])
-        self.set_parent(context, self.set_parent(first, second))
-
-        self.replay()
-        self.assertEqual(handlers.find_quota_parent(context), first)
-
-    def test_is_in_factory(self):
-        context = self.providing_stub([IFactoryTempFolder])
-        first = self.stub()
-        second = self.providing_stub([IBaseObject])
-        third = self.providing_stub([IBaseObject, IQuotaSupport])
-
-        self.set_parent(context,
-            self.set_parent(first,
-                self.set_parent(second, third)))
-
-        self.replay()
-        self.assertEqual(handlers.find_quota_parent(context), third)
+        folder = create(Builder('folder'))
+        document = create(Builder('file').within(folder))
+        self.assertEqual(folder, handlers.find_quota_parent(document))
 
     def test_stop_when_site_root_reached(self):
-        context = self.providing_stub([IBaseObject])
-        root = self.providing_stub([IBaseObject, ISiteRoot])
-        self.set_parent(context, root)
-
-        self.replay()
-        self.assertEqual(handlers.find_quota_parent(context), None)
-
-    def test_stop_when_not_AT_object(self):
-        context = self.stub()
-        self.replay()
-        self.assertEqual(handlers.find_quota_parent(context), None)
-
-    def test_stop_when_parent_not_AT_object(self):
-        context = self.providing_stub([IBaseObject])
-        parent = self.stub()
-        self.set_parent(context, parent)
-
-        self.replay()
-        self.assertEqual(handlers.find_quota_parent(context), None)
-
-    def test_not_looping_on_wrong_input(self):
-        context = None
-        self.replay()
-        self.assertEqual(handlers.find_quota_parent(context), None)
+        document = create(Builder('file'))
+        self.assertEqual(None, handlers.find_quota_parent(document))
 
 
-class TestObjectAddedOrModified(MockTestCase):
-
-    layer = ZCML_LAYER
+class TestObjectAddedOrModified(TestCase):
+    layer = FTW_QUOTA_INTEGRATION_TESTING
 
     def test_object_added_increases_usage(self):
-        container = self.providing_mock([IBaseObject, IQuotaSupport])
-        context = self.providing_stub(
-            [IBaseObject, IAttributeAnnotatable, IQuotaAware])
-        self.set_parent(context, container)
-
-        self.expect(context.get_size()).result(5)
-
-        schema = self.mocker.mock()
-        self.expect(container.Schema()).result(schema).count(0, None)
-        self.expect(schema.getField('quota').get(container)).result(100)
-        self.expect(schema.getField('usage').get(container)).result(10)
-        self.expect(schema.getField('usage').set(container, 15))
-
-        self.replay()
-
-        handlers.object_added_or_modified(context, None)
+        folder = create(Builder('folder'))
+        self.assertEquals(0, folder.getField('usage').get(folder))
+        create(Builder('file')
+               .within(folder)
+               .attach_file_containing(' ' * 10))
+        self.assertEquals(10, folder.getField('usage').get(folder))

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,9 @@ version = '1.1.dev0'
 maintainer = 'Thomas Buchberger'
 
 tests_require = [
-    'plone.app.testing',
+    'ftw.builder',
     'ftw.testing',
+    'plone.app.testing',
     ]
 
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,6 @@ setup(name='ftw.quota',
 
       classifiers=[
         'Framework :: Plone',
-        'Framework :: Plone :: 4.0',
         'Framework :: Plone :: 4.1',
         'Framework :: Plone :: 4.2',
         'Programming Language :: Python',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ maintainer = 'Thomas Buchberger'
 
 tests_require = [
     'ftw.builder',
-    'ftw.testing',
     'plone.app.testing',
     ]
 

--- a/test-plone-4.0.x.cfg
+++ b/test-plone-4.0.x.cfg
@@ -1,6 +1,5 @@
 [buildout]
 extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.0.x.cfg
-    versions.cfg
 
 package-name = ftw.quota

--- a/test-plone-4.0.x.cfg
+++ b/test-plone-4.0.x.cfg
@@ -1,5 +1,0 @@
-[buildout]
-extends =
-    https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.0.x.cfg
-
-package-name = ftw.quota

--- a/test-plone-4.1.x.cfg
+++ b/test-plone-4.1.x.cfg
@@ -1,6 +1,5 @@
 [buildout]
 extends =
     https://raw.github.com/4teamwork/ftw-buildouts/master/test-plone-4.1.x.cfg
-    versions.cfg
 
 package-name = ftw.quota

--- a/versions.cfg
+++ b/versions.cfg
@@ -1,5 +1,0 @@
-[versions]
-# zope.testrunner 4.4.5 has changed the testing layer ordering
-# which causes test isolation problems with PloneTestCase layers
-# which are not isolating properly.
-zope.testrunner = 4.4.4


### PR DESCRIPTION
Drop Plone 4.0 support as ftw.builder does not support it.

The mocktests had isolation problems because schemaextender was included in the ZCML layer.
I've replaced all mocktests.
